### PR TITLE
Feat: Silenced warnings in tests.

### DIFF
--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 extern crate config;
 extern crate serde_derive;
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "toml")]
+#![allow(dead_code)]
 
 extern crate config;
 

--- a/tests/legacy/errors.rs
+++ b/tests/legacy/errors.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "toml")]
+#![allow(dead_code)]
 
 extern crate config;
 


### PR DESCRIPTION
There are some warnings present in the `tests` directory that shouldn't be visible, as we don't really care about clippy being happy in tests.